### PR TITLE
Single shot to download packages

### DIFF
--- a/install-FruityWifi-rpi.sh
+++ b/install-FruityWifi-rpi.sh
@@ -42,9 +42,8 @@ cd tmp-install
 apt-get update
 
 # DEP HOSTAPD-KARMA
-apt-get -y install libnl1 
-apt-get -y install libnl-dev 
-apt-get -y install libssl-dev
+apt-get -y install libnl1  libnl-dev libssl-dev
+
 
 # INSTALL HOSTAPD-KARMA
 #wget http://www.digininja.org/files/hostapd-1.0-karma.patch.bz2


### PR DESCRIPTION
you could try to change your option 
apt-get -y install singlepackage to
apt-get -y install multiple package 
this change minimize the connections to the repository,also reduce the time of execution.

If you have a text file containing a list of software packages to install, you can bulk install all the packages in one shot as follows.

apt-get install -y `cat package.txt | tr "\n" " "`
